### PR TITLE
add ampq topolgy builder to create the ampq underlying topology

### DIFF
--- a/lib/sample/index.ts
+++ b/lib/sample/index.ts
@@ -1,11 +1,9 @@
 import { Event } from "inspector-metrics";
-import { AmqpMetricReporter } from "../metrics";
+import { AmqpMetricReporter, AmqpTopologyHelper } from "../metrics";
 
 // instance the Amqp reporter
 const reporter: AmqpMetricReporter = new AmqpMetricReporter({
-  connection: "amqp://localhost",
-  exchangeName: "exchange",
-  queueName: "queue",
+  amqpTopologyBuilder: AmqpTopologyHelper.queue("amqp://localhost", "queue"),
 });
 
 // start reporter


### PR DESCRIPTION
Added an `AmqpTopologyBuilder` type to let the end user create the underlying amqp topology (exchanges, queues, and bindings).

Also added an `AmqpTopologyHelper` to ease creation of simple topologies like single queue or single exchange bound to a single queue.